### PR TITLE
Add day/week notes, daily/weekly reports, grouped history, and CSV export

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,6 +4,7 @@ import cookieParser from "cookie-parser";
 import { authRouter } from "./routes/auth.js";
 import { sessionsRouter } from "./routes/sessions.js";
 import { projectsRouter } from "./routes/projects.js";
+import { notesRouter } from "./routes/notes.js";
 
 export const app = express();
 app.set("etag", false);
@@ -21,5 +22,6 @@ app.use((_req, res, next) => {
 app.use("/api/auth", authRouter);
 app.use("/api/sessions", sessionsRouter);
 app.use("/api/projects", projectsRouter);
+app.use("/api/notes", notesRouter);
 
 app.get("/api/health", (_req, res) => res.json({ ok: true }));

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -57,4 +57,17 @@ export async function initDb() {
   } catch {
     // column already exists
   }
+
+  await db.execute(`
+    CREATE TABLE IF NOT EXISTS notes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL REFERENCES users(id),
+      scope TEXT NOT NULL CHECK (scope IN ('day', 'week')),
+      date_key TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE (user_id, scope, date_key)
+    )
+  `);
 }

--- a/backend/src/routes/notes.ts
+++ b/backend/src/routes/notes.ts
@@ -1,0 +1,75 @@
+import { Router } from "express";
+import { db } from "../db.js";
+import { requireAuth, AuthRequest } from "../middleware/auth.js";
+
+export const notesRouter = Router();
+
+notesRouter.use(requireAuth);
+
+const DATE_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+notesRouter.get("/", async (req: AuthRequest, res) => {
+  const result = await db.execute({
+    sql: "SELECT id, scope, date_key, content, updated_at FROM notes WHERE user_id = ?",
+    args: [req.userId!],
+  });
+
+  res.json(result.rows);
+});
+
+notesRouter.put("/:scope/:dateKey", async (req: AuthRequest, res) => {
+  const scope = req.params.scope as string;
+  const dateKey = req.params.dateKey as string;
+  const { content } = req.body ?? {};
+
+  if (scope !== "day" && scope !== "week") {
+    return res.status(400).json({ error: "scope must be 'day' or 'week'" });
+  }
+  if (!DATE_KEY_RE.test(dateKey)) {
+    return res.status(400).json({ error: "dateKey must be in YYYY-MM-DD format" });
+  }
+  if (typeof content !== "string") {
+    return res.status(400).json({ error: "content is required" });
+  }
+
+  const trimmed = content.trim();
+
+  if (trimmed.length === 0) {
+    await db.execute({
+      sql: "DELETE FROM notes WHERE user_id = ? AND scope = ? AND date_key = ?",
+      args: [req.userId!, scope, dateKey],
+    });
+    return res.status(204).send();
+  }
+
+  const updatedAt = new Date().toISOString();
+
+  await db.execute({
+    sql: `
+      INSERT INTO notes (user_id, scope, date_key, content, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT (user_id, scope, date_key)
+      DO UPDATE SET content = excluded.content, updated_at = excluded.updated_at
+    `,
+    args: [req.userId!, scope, dateKey, trimmed, updatedAt],
+  });
+
+  const result = await db.execute({
+    sql: "SELECT id, scope, date_key, content, updated_at FROM notes WHERE user_id = ? AND scope = ? AND date_key = ?",
+    args: [req.userId!, scope, dateKey],
+  });
+
+  res.json(result.rows[0]);
+});
+
+notesRouter.delete("/:scope/:dateKey", async (req: AuthRequest, res) => {
+  const scope = req.params.scope as string;
+  const dateKey = req.params.dateKey as string;
+
+  await db.execute({
+    sql: "DELETE FROM notes WHERE user_id = ? AND scope = ? AND date_key = ?",
+    args: [req.userId!, scope, dateKey],
+  });
+
+  res.status(204).send();
+});

--- a/frontend/app/app/stats/page.tsx
+++ b/frontend/app/app/stats/page.tsx
@@ -1,42 +1,15 @@
 "use client";
 
-import { useEffect, useState, FormEvent } from "react";
-import { Trophy, Hourglass, BarChart3, Layers, History as HistoryIcon, Trash2, Plus, Pencil } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
+import { useEffect, useState } from "react";
+import { Trophy, Hourglass, BarChart3, Layers } from "lucide-react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from "@/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogTrigger,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogCancel,
-  AlertDialogAction,
-} from "@/components/ui/alert-dialog";
-import { sessions as sessionsApi, projects as projectsApi, ApiError, StudySession, Project } from "@/lib/api";
+import { sessions as sessionsApi, projects as projectsApi, notes as notesApi, StudySession, Project, Note } from "@/lib/api";
 import { ProjectIcon } from "@/lib/icons";
+import { dayKey, formatDuration } from "@/lib/date";
+import { dailyTotals, projectTotals as computeProjectTotals, NO_PROJECT_LABEL } from "@/lib/session-stats";
+import { ReportCards } from "@/components/report-cards";
+import { HistorySection } from "@/components/history-section";
 
 const WEEKS = 14;
 const DAYS = WEEKS * 7;
@@ -45,29 +18,6 @@ const WEEKDAY_LABELS = ["", "Mon", "", "Wed", "", "Fri", ""];
 const MONTH_LABELS = [
   "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
-const NO_PROJECT_LABEL = "No project";
-
-function dayKey(date: Date) {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
-
-function formatDuration(totalSeconds: number) {
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  if (hours === 0) return `${minutes}m`;
-  return `${hours}h ${minutes}m`;
-}
-
-function formatTime(dateStr: string) {
-  return new Date(dateStr).toLocaleTimeString(undefined, {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-}
 
 function intensityColor(seconds: number) {
   if (seconds === 0) return undefined; // falls back to bg-muted
@@ -113,70 +63,12 @@ function monthLabelForWeek(week: (Day | null)[], previousWeek: (Day | null)[] | 
   return MONTH_LABELS[firstDay.date.getMonth()];
 }
 
-const DESCRIPTION_PREVIEW_LENGTH = 80;
-const NO_PROJECT_VALUE = "__none__";
-
-function pad(n: number) {
-  return String(n).padStart(2, "0");
-}
-
-function toDateInput(date: Date) {
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
-}
-
-function toTimeInput(date: Date) {
-  return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
-}
-
 export default function StatsPage() {
   const [sessionList, setSessionList] = useState<StudySession[]>([]);
   const [projectList, setProjectList] = useState<Project[]>([]);
+  const [noteList, setNoteList] = useState<Note[]>([]);
   const [loading, setLoading] = useState(true);
   const [now, setNow] = useState(() => Date.now());
-  const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
-
-  const [addOpen, setAddOpen] = useState(false);
-  const [editingId, setEditingId] = useState<number | null>(null);
-  const [addDate, setAddDate] = useState(() => toDateInput(new Date()));
-  const [addStartTime, setAddStartTime] = useState(() => toTimeInput(new Date(Date.now() - 60 * 60 * 1000)));
-  const [addEndTime, setAddEndTime] = useState(() => toTimeInput(new Date()));
-  const [addProjectId, setAddProjectId] = useState<number | null>(null);
-  const [addDescription, setAddDescription] = useState("");
-  const [addError, setAddError] = useState<string | null>(null);
-  const [addBusy, setAddBusy] = useState(false);
-
-  function openAddDialog() {
-    setEditingId(null);
-    setAddDate(toDateInput(new Date()));
-    setAddStartTime(toTimeInput(new Date(Date.now() - 60 * 60 * 1000)));
-    setAddEndTime(toTimeInput(new Date()));
-    setAddProjectId(null);
-    setAddDescription("");
-    setAddError(null);
-    setAddOpen(true);
-  }
-
-  function openEditDialog(session: StudySession) {
-    const start = new Date(session.started_at);
-    const end = session.ended_at ? new Date(session.ended_at) : new Date();
-    setEditingId(session.id);
-    setAddDate(toDateInput(start));
-    setAddStartTime(toTimeInput(start));
-    setAddEndTime(toTimeInput(end));
-    setAddProjectId(session.project_id);
-    setAddDescription(session.description ?? "");
-    setAddError(null);
-    setAddOpen(true);
-  }
-
-  function toggleExpanded(id: number) {
-    setExpandedIds((current) => {
-      const next = new Set(current);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }
 
   useEffect(() => {
     sessionsApi
@@ -184,6 +76,7 @@ export default function StatsPage() {
       .then(setSessionList)
       .finally(() => setLoading(false));
     projectsApi.list().then(setProjectList).catch(() => {});
+    notesApi.list().then(setNoteList).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -193,124 +86,29 @@ export default function StatsPage() {
     return () => clearInterval(interval);
   }, [sessionList]);
 
-  // Include the in-progress session's elapsed-so-far time in stats too, using its live
-  // duration (computed from `now`) instead of waiting until it's stopped to count it.
-  const forStats = sessionList
-    .map((s) => ({
-      ...s,
-      duration_seconds:
-        s.ended_at === null
-          ? Math.max(0, Math.floor((now - new Date(s.started_at).getTime()) / 1000))
-          : s.duration_seconds,
-    }))
-    .filter((s) => s.duration_seconds !== null);
-
-  const totalsByDay = new Map<string, number>();
-  for (const session of forStats) {
-    const key = dayKey(new Date(session.started_at));
-    totalsByDay.set(key, (totalsByDay.get(key) ?? 0) + session.duration_seconds!);
+  function handleNoteSaved(note: Note) {
+    setNoteList((list) => {
+      const withoutExisting = list.filter((n) => !(n.scope === note.scope && n.date_key === note.date_key));
+      return [...withoutExisting, note];
+    });
   }
+
+  function handleNoteDeleted(scope: "day" | "week", dateKey: string) {
+    setNoteList((list) => list.filter((n) => !(n.scope === scope && n.date_key === dateKey)));
+  }
+
+  // dailyTotals/computeProjectTotals include the in-progress session's elapsed-so-far time,
+  // using its live duration (computed from `now`) instead of waiting until it's stopped.
+  const totalsByDay = dailyTotals(sessionList, now);
 
   const heatmapDays = buildLastNDays(totalsByDay, DAYS);
   const weeks = buildHeatmapWeeks(heatmapDays);
   const barDays = buildLastNDays(totalsByDay, BAR_CHART_DAYS);
   const maxBarSeconds = Math.max(1, ...barDays.map((d) => d.seconds));
 
-  const projectTotals = new Map<string, { name: string; icon: string | null; seconds: number }>();
-  for (const session of forStats) {
-    const key = session.project_id !== null ? String(session.project_id) : "none";
-    const name = session.project_name ?? NO_PROJECT_LABEL;
-    const existing = projectTotals.get(key);
-    projectTotals.set(key, {
-      name,
-      icon: session.project_icon,
-      seconds: (existing?.seconds ?? 0) + session.duration_seconds!,
-    });
-  }
-  const breakdown = Array.from(projectTotals.values()).sort((a, b) => b.seconds - a.seconds);
+  const breakdown = computeProjectTotals(sessionList, now);
   const maxProjectSeconds = Math.max(1, ...breakdown.map((p) => p.seconds));
   const topProject = breakdown.filter((p) => p.name !== NO_PROJECT_LABEL)[0] ?? null;
-
-  async function handleDeleteSession(id: number) {
-    try {
-      await sessionsApi.remove(id);
-      setSessionList((list) => list.filter((s) => s.id !== id));
-    } catch {
-      // best-effort; leave the session in place if the delete failed
-    }
-  }
-
-  async function handleAddSession(e: FormEvent) {
-    e.preventDefault();
-    setAddError(null);
-
-    const startedAt = new Date(`${addDate}T${addStartTime}`);
-    const endedAt = new Date(`${addDate}T${addEndTime}`);
-
-    if (endedAt <= startedAt) {
-      setAddError("End time must be after start time");
-      return;
-    }
-
-    const project = projectList.find((p) => p.id === addProjectId) ?? null;
-
-    setAddBusy(true);
-    try {
-      if (editingId !== null) {
-        await sessionsApi.update(editingId, {
-          startedAt: startedAt.toISOString(),
-          endedAt: endedAt.toISOString(),
-          projectId: addProjectId,
-          description: addDescription || null,
-        });
-        setSessionList((list) =>
-          list
-            .map((s) =>
-              s.id === editingId
-                ? {
-                    ...s,
-                    started_at: startedAt.toISOString(),
-                    ended_at: endedAt.toISOString(),
-                    duration_seconds: Math.round((endedAt.getTime() - startedAt.getTime()) / 1000),
-                    description: addDescription || null,
-                    project_id: addProjectId,
-                    project_name: project?.name ?? null,
-                    project_icon: project?.icon ?? null,
-                  }
-                : s
-            )
-            .sort((a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime())
-        );
-      } else {
-        const created = await sessionsApi.createManual({
-          startedAt: startedAt.toISOString(),
-          endedAt: endedAt.toISOString(),
-          projectId: addProjectId,
-          description: addDescription || null,
-        });
-        setSessionList((list) =>
-          [
-            {
-              id: created.id,
-              started_at: created.startedAt,
-              ended_at: created.endedAt,
-              duration_seconds: created.durationSeconds,
-              description: addDescription || null,
-              project_id: addProjectId,
-              project_name: project?.name ?? null,
-              project_icon: project?.icon ?? null,
-            },
-            ...list,
-          ].sort((a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime())
-        );
-      }
-      setAddOpen(false);
-    } catch (err) {
-      setAddError(err instanceof ApiError ? err.message : "Something went wrong");
-    } finally {
-      setAddBusy(false);
-    }
-  }
 
   if (loading) {
     return (
@@ -322,6 +120,14 @@ export default function StatsPage() {
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-8">
+      <ReportCards
+        sessions={sessionList}
+        notes={noteList}
+        now={now}
+        onNoteSaved={handleNoteSaved}
+        onNoteDeleted={handleNoteDeleted}
+      />
+
       <div className="flex flex-wrap items-stretch gap-4 sm:gap-8">
         <Card className="w-full shrink-0 sm:w-auto">
           <CardHeader>
@@ -468,7 +274,7 @@ export default function StatsPage() {
             )}
             <div className="space-y-3">
               {breakdown.map((project) => (
-                <div key={project.name} className="space-y-1">
+                <div key={project.key} className="space-y-1">
                   <div className="flex justify-between text-sm">
                     <span className="flex items-center gap-1.5">
                       <ProjectIcon icon={project.icon} className="text-muted-foreground size-3.5" />
@@ -489,216 +295,15 @@ export default function StatsPage() {
         </Card>
       </div>
 
-      <Card>
-        <CardHeader className="flex flex-wrap items-center justify-between gap-2">
-          <CardTitle className="flex items-center gap-2">
-            <HistoryIcon className="text-muted-foreground size-4" />
-            History
-          </CardTitle>
-          <Button variant="outline" size="sm" className="gap-1" onClick={openAddDialog}>
-            <Plus className="size-4" />
-            Add session
-          </Button>
-          <Dialog open={addOpen} onOpenChange={setAddOpen}>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>{editingId !== null ? "Edit session" : "Add a session"}</DialogTitle>
-                <DialogDescription>
-                  {editingId !== null
-                    ? "Fix a session that ran long, or update its details."
-                    : "For time you forgot to track live. It's added as an already-finished session."}
-                </DialogDescription>
-              </DialogHeader>
-              <form className="space-y-4" onSubmit={handleAddSession}>
-                <div className="space-y-2">
-                  <Label htmlFor="add-date">Date</Label>
-                  <Input
-                    id="add-date"
-                    type="date"
-                    value={addDate}
-                    onChange={(e) => setAddDate(e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="space-y-2">
-                    <Label htmlFor="add-start">Start time</Label>
-                    <Input
-                      id="add-start"
-                      type="time"
-                      value={addStartTime}
-                      onChange={(e) => setAddStartTime(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="add-end">End time</Label>
-                    <Input
-                      id="add-end"
-                      type="time"
-                      value={addEndTime}
-                      onChange={(e) => setAddEndTime(e.target.value)}
-                      required
-                    />
-                  </div>
-                </div>
-                <div className="space-y-2">
-                  <Label>Project</Label>
-                  <Select
-                    value={addProjectId !== null ? String(addProjectId) : NO_PROJECT_VALUE}
-                    onValueChange={(value) =>
-                      setAddProjectId(value === NO_PROJECT_VALUE ? null : Number(value))
-                    }
-                  >
-                    <SelectTrigger className="w-full">
-                      <SelectValue>
-                        {(value: string) => {
-                          const project = projectList.find((p) => String(p.id) === value);
-                          return (
-                            <span className="flex items-center gap-2">
-                              <ProjectIcon icon={project?.icon ?? null} className="size-4" />
-                              {project?.name ?? "No project"}
-                            </span>
-                          );
-                        }}
-                      </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={NO_PROJECT_VALUE}>
-                        <ProjectIcon icon={null} className="size-4" />
-                        No project
-                      </SelectItem>
-                      {projectList.map((project) => (
-                        <SelectItem key={project.id} value={String(project.id)}>
-                          <ProjectIcon icon={project.icon} className="size-4" />
-                          {project.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="add-description">Description (optional)</Label>
-                  <Textarea
-                    id="add-description"
-                    value={addDescription}
-                    onChange={(e) => setAddDescription(e.target.value)}
-                    placeholder="What were you working on?"
-                  />
-                </div>
-                {addError && <p className="text-destructive text-sm">{addError}</p>}
-                <DialogFooter>
-                  <Button type="submit" disabled={addBusy}>
-                    {addBusy ? "Adding..." : "Add session"}
-                  </Button>
-                </DialogFooter>
-              </form>
-            </DialogContent>
-          </Dialog>
-        </CardHeader>
-        <CardContent>
-          {sessionList.length === 0 && (
-            <p className="text-muted-foreground text-sm">No sessions yet, start one on Home.</p>
-          )}
-          <div className="space-y-2">
-            {sessionList.map((session) => {
-              const isActive = session.ended_at === null;
-              const seconds = isActive
-                ? Math.floor((now - new Date(session.started_at).getTime()) / 1000)
-                : (session.duration_seconds ?? 0);
-
-              const isExpanded = expandedIds.has(session.id);
-              const isLong =
-                !!session.description &&
-                (session.description.length > DESCRIPTION_PREVIEW_LENGTH || session.description.includes("\n"));
-
-              return (
-              <div key={session.id} className="flex flex-col gap-2 rounded-lg ring-1 ring-foreground/10 px-3 py-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
-                <div className="min-w-0 flex-1 space-y-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-medium">
-                      {new Date(session.started_at).toLocaleDateString(undefined, {
-                        month: "short",
-                        day: "numeric",
-                      })}
-                    </span>
-                    <span className="text-muted-foreground font-mono text-xs">
-                      {formatTime(session.started_at)}
-                      {"-"}
-                      {session.ended_at ? formatTime(session.ended_at) : "now"}
-                    </span>
-                    <Badge variant={session.project_name ? "secondary" : "outline"} className="gap-1">
-                      <ProjectIcon icon={session.project_icon} className="size-3" />
-                      {session.project_name ?? NO_PROJECT_LABEL}
-                    </Badge>
-                    {isActive && (
-                      <Badge className="bg-primary/15 text-primary gap-1">
-                        <span className="bg-primary size-1.5 animate-pulse rounded-full" />
-                        In progress
-                      </Badge>
-                    )}
-                  </div>
-                  {session.description && (
-                    <div>
-                      <p
-                        className={`text-muted-foreground text-sm whitespace-pre-wrap ${isExpanded ? "" : "line-clamp-2"}`}
-                      >
-                        {session.description}
-                      </p>
-                      {isLong && (
-                        <button
-                          type="button"
-                          onClick={() => toggleExpanded(session.id)}
-                          className="text-primary text-xs hover:underline"
-                        >
-                          {isExpanded ? "Show less" : "Show more"}
-                        </button>
-                      )}
-                    </div>
-                  )}
-                </div>
-                <div className="flex shrink-0 items-center justify-between gap-3 sm:justify-end">
-                  <span className="font-mono text-sm whitespace-nowrap">
-                    {formatDuration(seconds)}
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    className="text-muted-foreground"
-                    onClick={() => openEditDialog(session)}
-                  >
-                    <Pencil />
-                  </Button>
-                  <AlertDialog>
-                    <AlertDialogTrigger
-                      render={
-                        <Button variant="ghost" size="icon-sm" className="text-muted-foreground hover:text-destructive">
-                          <Trash2 />
-                        </Button>
-                      }
-                    />
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Delete this session?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          This will permanently delete this study session and its recorded time. This can&apos;t be undone.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction onClick={() => handleDeleteSession(session.id)}>
-                          Delete
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                </div>
-              </div>
-              );
-            })}
-          </div>
-        </CardContent>
-      </Card>
+      <HistorySection
+        sessions={sessionList}
+        projects={projectList}
+        notes={noteList}
+        now={now}
+        onSessionsChange={setSessionList}
+        onNoteSaved={handleNoteSaved}
+        onNoteDeleted={handleNoteDeleted}
+      />
     </div>
   );
 }

--- a/frontend/components/history-section.tsx
+++ b/frontend/components/history-section.tsx
@@ -1,0 +1,600 @@
+"use client";
+
+import { useState, FormEvent } from "react";
+import { History as HistoryIcon, Trash2, Plus, Pencil, Download, ChevronDown, ChevronRight } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
+import { sessions as sessionsApi, ApiError, StudySession, Project, Note } from "@/lib/api";
+import { ProjectIcon } from "@/lib/icons";
+import { NoteEditor } from "@/components/note-editor";
+import { exportSessions } from "@/lib/export";
+import { sessionDurationSeconds } from "@/lib/session-stats";
+import {
+  dayKey,
+  weekKey,
+  startOfDay,
+  startOfWeek,
+  formatDuration,
+  formatTime,
+  formatDayLabel,
+  formatWeekRangeLabel,
+} from "@/lib/date";
+
+const NO_PROJECT_LABEL = "No project";
+const DESCRIPTION_PREVIEW_LENGTH = 80;
+const NO_PROJECT_VALUE = "__none__";
+
+function pad(n: number) {
+  return String(n).padStart(2, "0");
+}
+
+function toDateInput(date: Date) {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+function toTimeInput(date: Date) {
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+type DayGroup = { key: string; date: Date; sessions: StudySession[]; totalSeconds: number };
+type WeekGroup = { key: string; weekStart: Date; days: DayGroup[]; sessions: StudySession[]; totalSeconds: number };
+
+/** Sessions arrive newest-first; grouping by first-seen key preserves that order for weeks and days. */
+function groupSessions(sessionList: StudySession[], now: number): WeekGroup[] {
+  const weeks: WeekGroup[] = [];
+  const weekIndex = new Map<string, WeekGroup>();
+  const dayIndex = new Map<string, DayGroup>();
+
+  for (const session of sessionList) {
+    const started = new Date(session.started_at);
+    const wKey = weekKey(started);
+    const dKey = dayKey(started);
+    const seconds = sessionDurationSeconds(session, now);
+
+    let week = weekIndex.get(wKey);
+    if (!week) {
+      week = { key: wKey, weekStart: startOfWeek(started), days: [], sessions: [], totalSeconds: 0 };
+      weekIndex.set(wKey, week);
+      weeks.push(week);
+    }
+
+    let day = dayIndex.get(`${wKey}:${dKey}`);
+    if (!day) {
+      day = { key: dKey, date: startOfDay(started), sessions: [], totalSeconds: 0 };
+      dayIndex.set(`${wKey}:${dKey}`, day);
+      week.days.push(day);
+    }
+
+    day.sessions.push(session);
+    day.totalSeconds += seconds;
+    week.sessions.push(session);
+    week.totalSeconds += seconds;
+  }
+
+  return weeks;
+}
+
+export function HistorySection({
+  sessions: sessionList,
+  projects: projectList,
+  notes,
+  now,
+  onSessionsChange,
+  onNoteSaved,
+  onNoteDeleted,
+}: {
+  sessions: StudySession[];
+  projects: Project[];
+  notes: Note[];
+  now: number;
+  onSessionsChange: (updater: (list: StudySession[]) => StudySession[]) => void;
+  onNoteSaved: (note: Note) => void;
+  onNoteDeleted: (scope: "day" | "week", dateKey: string) => void;
+}) {
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
+  const [collapsedWeeks, setCollapsedWeeks] = useState<Set<string>>(new Set());
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [addDate, setAddDate] = useState(() => toDateInput(new Date()));
+  const [addStartTime, setAddStartTime] = useState(() => toTimeInput(new Date(Date.now() - 60 * 60 * 1000)));
+  const [addEndTime, setAddEndTime] = useState(() => toTimeInput(new Date()));
+  const [addProjectId, setAddProjectId] = useState<number | null>(null);
+  const [addDescription, setAddDescription] = useState("");
+  const [addError, setAddError] = useState<string | null>(null);
+  const [addBusy, setAddBusy] = useState(false);
+
+  function openAddDialog() {
+    setEditingId(null);
+    setAddDate(toDateInput(new Date()));
+    setAddStartTime(toTimeInput(new Date(Date.now() - 60 * 60 * 1000)));
+    setAddEndTime(toTimeInput(new Date()));
+    setAddProjectId(null);
+    setAddDescription("");
+    setAddError(null);
+    setAddOpen(true);
+  }
+
+  function openEditDialog(session: StudySession) {
+    const start = new Date(session.started_at);
+    const end = session.ended_at ? new Date(session.ended_at) : new Date();
+    setEditingId(session.id);
+    setAddDate(toDateInput(start));
+    setAddStartTime(toTimeInput(start));
+    setAddEndTime(toTimeInput(end));
+    setAddProjectId(session.project_id);
+    setAddDescription(session.description ?? "");
+    setAddError(null);
+    setAddOpen(true);
+  }
+
+  function toggleExpanded(id: number) {
+    setExpandedIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleWeekCollapsed(key: string) {
+    setCollapsedWeeks((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  async function handleDeleteSession(id: number) {
+    try {
+      await sessionsApi.remove(id);
+      onSessionsChange((list) => list.filter((s) => s.id !== id));
+    } catch {
+      // best-effort; leave the session in place if the delete failed
+    }
+  }
+
+  async function handleAddSession(e: FormEvent) {
+    e.preventDefault();
+    setAddError(null);
+
+    const startedAt = new Date(`${addDate}T${addStartTime}`);
+    const endedAt = new Date(`${addDate}T${addEndTime}`);
+
+    if (endedAt <= startedAt) {
+      setAddError("End time must be after start time");
+      return;
+    }
+
+    const project = projectList.find((p) => p.id === addProjectId) ?? null;
+
+    setAddBusy(true);
+    try {
+      if (editingId !== null) {
+        await sessionsApi.update(editingId, {
+          startedAt: startedAt.toISOString(),
+          endedAt: endedAt.toISOString(),
+          projectId: addProjectId,
+          description: addDescription || null,
+        });
+        onSessionsChange((list) =>
+          list
+            .map((s) =>
+              s.id === editingId
+                ? {
+                    ...s,
+                    started_at: startedAt.toISOString(),
+                    ended_at: endedAt.toISOString(),
+                    duration_seconds: Math.round((endedAt.getTime() - startedAt.getTime()) / 1000),
+                    description: addDescription || null,
+                    project_id: addProjectId,
+                    project_name: project?.name ?? null,
+                    project_icon: project?.icon ?? null,
+                  }
+                : s
+            )
+            .sort((a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime())
+        );
+      } else {
+        const created = await sessionsApi.createManual({
+          startedAt: startedAt.toISOString(),
+          endedAt: endedAt.toISOString(),
+          projectId: addProjectId,
+          description: addDescription || null,
+        });
+        onSessionsChange((list) =>
+          [
+            {
+              id: created.id,
+              started_at: created.startedAt,
+              ended_at: created.endedAt,
+              duration_seconds: created.durationSeconds,
+              description: addDescription || null,
+              project_id: addProjectId,
+              project_name: project?.name ?? null,
+              project_icon: project?.icon ?? null,
+            },
+            ...list,
+          ].sort((a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime())
+        );
+      }
+      setAddOpen(false);
+    } catch (err) {
+      setAddError(err instanceof ApiError ? err.message : "Something went wrong");
+    } finally {
+      setAddBusy(false);
+    }
+  }
+
+  const weeks = groupSessions(sessionList, now);
+
+  function findNote(scope: "day" | "week", key: string) {
+    return notes.find((n) => n.scope === scope && n.date_key === key);
+  }
+
+  function exportFilename(scope: "all" | "week" | "day", key: string) {
+    const today = toDateInput(new Date());
+    if (scope === "all") return `sentinel-sessions-all-${today}.csv`;
+    if (scope === "week") return `sentinel-sessions-week-${key}.csv`;
+    return `sentinel-sessions-${key}.csv`;
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-wrap items-center justify-between gap-2">
+        <CardTitle className="flex items-center gap-2">
+          <HistoryIcon className="text-muted-foreground size-4" />
+          History
+        </CardTitle>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1"
+            disabled={sessionList.length === 0}
+            onClick={() => exportSessions(exportFilename("all", ""), sessionList, now)}
+          >
+            <Download className="size-4" />
+            Export all
+          </Button>
+          <Button variant="outline" size="sm" className="gap-1" onClick={openAddDialog}>
+            <Plus className="size-4" />
+            Add session
+          </Button>
+        </div>
+        <Dialog open={addOpen} onOpenChange={setAddOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{editingId !== null ? "Edit session" : "Add a session"}</DialogTitle>
+              <DialogDescription>
+                {editingId !== null
+                  ? "Fix a session that ran long, or update its details."
+                  : "For time you forgot to track live. It's added as an already-finished session."}
+              </DialogDescription>
+            </DialogHeader>
+            <form className="space-y-4" onSubmit={handleAddSession}>
+              <div className="space-y-2">
+                <Label htmlFor="add-date">Date</Label>
+                <Input
+                  id="add-date"
+                  type="date"
+                  value={addDate}
+                  onChange={(e) => setAddDate(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="add-start">Start time</Label>
+                  <Input
+                    id="add-start"
+                    type="time"
+                    value={addStartTime}
+                    onChange={(e) => setAddStartTime(e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="add-end">End time</Label>
+                  <Input
+                    id="add-end"
+                    type="time"
+                    value={addEndTime}
+                    onChange={(e) => setAddEndTime(e.target.value)}
+                    required
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label>Project</Label>
+                <Select
+                  value={addProjectId !== null ? String(addProjectId) : NO_PROJECT_VALUE}
+                  onValueChange={(value) =>
+                    setAddProjectId(value === NO_PROJECT_VALUE ? null : Number(value))
+                  }
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue>
+                      {(value: string) => {
+                        const project = projectList.find((p) => String(p.id) === value);
+                        return (
+                          <span className="flex items-center gap-2">
+                            <ProjectIcon icon={project?.icon ?? null} className="size-4" />
+                            {project?.name ?? "No project"}
+                          </span>
+                        );
+                      }}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NO_PROJECT_VALUE}>
+                      <ProjectIcon icon={null} className="size-4" />
+                      No project
+                    </SelectItem>
+                    {projectList.map((project) => (
+                      <SelectItem key={project.id} value={String(project.id)}>
+                        <ProjectIcon icon={project.icon} className="size-4" />
+                        {project.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="add-description">Description (optional)</Label>
+                <Textarea
+                  id="add-description"
+                  value={addDescription}
+                  onChange={(e) => setAddDescription(e.target.value)}
+                  placeholder="What were you working on?"
+                />
+              </div>
+              {addError && <p className="text-destructive text-sm">{addError}</p>}
+              <DialogFooter>
+                <Button type="submit" disabled={addBusy}>
+                  {addBusy ? "Adding..." : "Add session"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </CardHeader>
+      <CardContent>
+        {sessionList.length === 0 && (
+          <p className="text-muted-foreground text-sm">No sessions yet, start one on Home.</p>
+        )}
+        <div className="space-y-6">
+          {weeks.map((week) => {
+            const weekNote = findNote("week", week.key);
+            const weekCollapsed = collapsedWeeks.has(week.key);
+
+            return (
+              <div key={week.key} className="space-y-3">
+                <div className="flex flex-wrap items-start justify-between gap-2 border-b pb-2">
+                  <button
+                    type="button"
+                    onClick={() => toggleWeekCollapsed(week.key)}
+                    className="flex items-center gap-1.5 text-left"
+                  >
+                    {weekCollapsed ? (
+                      <ChevronRight className="text-muted-foreground size-4 shrink-0" />
+                    ) : (
+                      <ChevronDown className="text-muted-foreground size-4 shrink-0" />
+                    )}
+                    <span className="font-medium">{formatWeekRangeLabel(week.weekStart)}</span>
+                    <span className="text-muted-foreground font-mono text-xs">
+                      {formatDuration(week.totalSeconds)}
+                    </span>
+                  </button>
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          className="text-muted-foreground"
+                          onClick={() => exportSessions(exportFilename("week", week.key), week.sessions, now)}
+                        >
+                          <Download />
+                        </Button>
+                      }
+                    />
+                    <TooltipContent>Export this week as CSV</TooltipContent>
+                  </Tooltip>
+                </div>
+
+                {!weekCollapsed && (
+                  <>
+                    <div className="pl-5">
+                      <NoteEditor
+                        scope="week"
+                        dateKey={week.key}
+                        note={weekNote}
+                        label={formatWeekRangeLabel(week.weekStart)}
+                        onSaved={onNoteSaved}
+                        onDeleted={() => onNoteDeleted("week", week.key)}
+                      />
+                    </div>
+
+                    <div className="space-y-4 pl-5">
+                      {week.days.map((day) => {
+                        const dayNote = findNote("day", day.key);
+
+                        return (
+                          <div key={day.key} className="space-y-2">
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <div className="flex items-center gap-2">
+                                <span className="text-sm font-medium">{formatDayLabel(day.date)}</span>
+                                <span className="text-muted-foreground font-mono text-xs">
+                                  {formatDuration(day.totalSeconds)}
+                                </span>
+                              </div>
+                              <Tooltip>
+                                <TooltipTrigger
+                                  render={
+                                    <Button
+                                      variant="ghost"
+                                      size="icon-sm"
+                                      className="text-muted-foreground"
+                                      onClick={() => exportSessions(exportFilename("day", day.key), day.sessions, now)}
+                                    >
+                                      <Download />
+                                    </Button>
+                                  }
+                                />
+                                <TooltipContent>Export this day as CSV</TooltipContent>
+                              </Tooltip>
+                            </div>
+
+                            <NoteEditor
+                              scope="day"
+                              dateKey={day.key}
+                              note={dayNote}
+                              label={formatDayLabel(day.date)}
+                              onSaved={onNoteSaved}
+                              onDeleted={() => onNoteDeleted("day", day.key)}
+                            />
+
+                            <div className="space-y-2">
+                              {day.sessions.map((session) => {
+                                const isActive = session.ended_at === null;
+                                const seconds = sessionDurationSeconds(session, now);
+                                const isExpanded = expandedIds.has(session.id);
+                                const isLong =
+                                  !!session.description &&
+                                  (session.description.length > DESCRIPTION_PREVIEW_LENGTH ||
+                                    session.description.includes("\n"));
+
+                                return (
+                                  <div
+                                    key={session.id}
+                                    className="ring-foreground/10 flex flex-col gap-2 rounded-lg px-3 py-2 ring-1 sm:flex-row sm:items-start sm:justify-between sm:gap-4"
+                                  >
+                                    <div className="min-w-0 flex-1 space-y-1">
+                                      <div className="flex flex-wrap items-center gap-2">
+                                        <span className="text-muted-foreground font-mono text-xs">
+                                          {formatTime(session.started_at)}
+                                          {"-"}
+                                          {session.ended_at ? formatTime(session.ended_at) : "now"}
+                                        </span>
+                                        <Badge variant={session.project_name ? "secondary" : "outline"} className="gap-1">
+                                          <ProjectIcon icon={session.project_icon} className="size-3" />
+                                          {session.project_name ?? NO_PROJECT_LABEL}
+                                        </Badge>
+                                        {isActive && (
+                                          <Badge className="bg-primary/15 text-primary gap-1">
+                                            <span className="bg-primary size-1.5 animate-pulse rounded-full" />
+                                            In progress
+                                          </Badge>
+                                        )}
+                                      </div>
+                                      {session.description && (
+                                        <div>
+                                          <p
+                                            className={`text-muted-foreground text-sm whitespace-pre-wrap ${isExpanded ? "" : "line-clamp-2"}`}
+                                          >
+                                            {session.description}
+                                          </p>
+                                          {isLong && (
+                                            <button
+                                              type="button"
+                                              onClick={() => toggleExpanded(session.id)}
+                                              className="text-primary text-xs hover:underline"
+                                            >
+                                              {isExpanded ? "Show less" : "Show more"}
+                                            </button>
+                                          )}
+                                        </div>
+                                      )}
+                                    </div>
+                                    <div className="flex shrink-0 items-center justify-between gap-3 sm:justify-end">
+                                      <span className="font-mono text-sm whitespace-nowrap">
+                                        {formatDuration(seconds)}
+                                      </span>
+                                      <Button
+                                        variant="ghost"
+                                        size="icon-sm"
+                                        className="text-muted-foreground"
+                                        onClick={() => openEditDialog(session)}
+                                      >
+                                        <Pencil />
+                                      </Button>
+                                      <AlertDialog>
+                                        <AlertDialogTrigger
+                                          render={
+                                            <Button
+                                              variant="ghost"
+                                              size="icon-sm"
+                                              className="text-muted-foreground hover:text-destructive"
+                                            >
+                                              <Trash2 />
+                                            </Button>
+                                          }
+                                        />
+                                        <AlertDialogContent>
+                                          <AlertDialogHeader>
+                                            <AlertDialogTitle>Delete this session?</AlertDialogTitle>
+                                            <AlertDialogDescription>
+                                              This will permanently delete this study session and its recorded time.
+                                              This can&apos;t be undone.
+                                            </AlertDialogDescription>
+                                          </AlertDialogHeader>
+                                          <AlertDialogFooter>
+                                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                            <AlertDialogAction onClick={() => handleDeleteSession(session.id)}>
+                                              Delete
+                                            </AlertDialogAction>
+                                          </AlertDialogFooter>
+                                        </AlertDialogContent>
+                                      </AlertDialog>
+                                    </div>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/note-editor.tsx
+++ b/frontend/components/note-editor.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import { NotebookPen, Pencil, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { notes as notesApi, ApiError, Note } from "@/lib/api";
+
+export function NoteEditor({
+  scope,
+  dateKey,
+  note,
+  label,
+  onSaved,
+  onDeleted,
+}: {
+  scope: "day" | "week";
+  dateKey: string;
+  note: Note | undefined;
+  label: string;
+  onSaved: (note: Note) => void;
+  onDeleted: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(note?.content ?? "");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function startEdit() {
+    setValue(note?.content ?? "");
+    setError(null);
+    setEditing(true);
+  }
+
+  async function save() {
+    setBusy(true);
+    setError(null);
+    try {
+      const trimmed = value.trim();
+      const saved = await notesApi.upsert(scope, dateKey, trimmed);
+      if (saved) onSaved(saved);
+      else onDeleted();
+      setEditing(false);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Couldn't save note");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove() {
+    setBusy(true);
+    setError(null);
+    try {
+      await notesApi.upsert(scope, dateKey, "");
+      onDeleted();
+      setEditing(false);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Couldn't delete note");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (editing) {
+    return (
+      <div className="bg-muted/40 space-y-2 rounded-md p-2" onClick={(e) => e.stopPropagation()}>
+        <Textarea
+          autoFocus
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={`Add a note for ${label}...`}
+          className="bg-background min-h-16 text-sm"
+        />
+        {error && <p className="text-destructive text-xs">{error}</p>}
+        <div className="flex items-center gap-2">
+          <Button size="sm" type="button" onClick={save} disabled={busy}>
+            {busy ? "Saving..." : "Save"}
+          </Button>
+          <Button size="sm" type="button" variant="ghost" onClick={() => setEditing(false)} disabled={busy}>
+            Cancel
+          </Button>
+          {note && (
+            <Button
+              size="sm"
+              type="button"
+              variant="ghost"
+              className="text-destructive hover:text-destructive ml-auto"
+              onClick={remove}
+              disabled={busy}
+            >
+              <Trash2 className="size-3.5" />
+              Delete
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (note) {
+    return (
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          startEdit();
+        }}
+        className="group text-muted-foreground hover:bg-muted/50 flex w-full items-start gap-1.5 rounded-md px-1.5 py-1 text-left text-sm"
+      >
+        <NotebookPen className="mt-0.5 size-3.5 shrink-0" />
+        <span className="whitespace-pre-wrap">{note.content}</span>
+        <Pencil className="mt-0.5 size-3 shrink-0 opacity-0 group-hover:opacity-100" />
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        startEdit();
+      }}
+      className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs"
+    >
+      <NotebookPen className="size-3" />
+      Add note
+    </button>
+  );
+}

--- a/frontend/components/report-cards.tsx
+++ b/frontend/components/report-cards.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { CalendarDays, CalendarRange } from "lucide-react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { StudySession, Note } from "@/lib/api";
+import { NoteEditor } from "@/components/note-editor";
+import { dailyTotals, projectTotals, NO_PROJECT_LABEL } from "@/lib/session-stats";
+import {
+  dayKey,
+  addDays,
+  startOfWeek,
+  weekKey,
+  formatDuration,
+  formatWeekRangeLabel,
+  periodComparison,
+} from "@/lib/date";
+
+const WEEKDAY_SHORT = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function ComparisonLine({ diff, percent, previousLabel }: { diff: number; percent: number | null; previousLabel: string }) {
+  if (diff === 0 && percent === 0) {
+    return <p className="text-muted-foreground text-xs">Same as {previousLabel}</p>;
+  }
+  const sign = diff > 0 ? "+" : "-";
+  const magnitude = formatDuration(Math.abs(diff));
+  const percentText = percent === null ? "" : ` (${diff > 0 ? "+" : ""}${percent}%)`;
+  return (
+    <p className="text-muted-foreground text-xs">
+      {sign}
+      {magnitude}
+      {percentText} vs {previousLabel}
+    </p>
+  );
+}
+
+export function ReportCards({
+  sessions: sessionList,
+  notes,
+  now,
+  onNoteSaved,
+  onNoteDeleted,
+}: {
+  sessions: StudySession[];
+  notes: Note[];
+  now: number;
+  onNoteSaved: (note: Note) => void;
+  onNoteDeleted: (scope: "day" | "week", dateKey: string) => void;
+}) {
+  const today = new Date(now);
+  const yesterday = addDays(today, -1);
+  const todayKey = dayKey(today);
+  const yesterdayKey = dayKey(yesterday);
+
+  const totalsByDay = dailyTotals(sessionList, now);
+  const todaySeconds = totalsByDay.get(todayKey) ?? 0;
+  const yesterdaySeconds = totalsByDay.get(yesterdayKey) ?? 0;
+  const todayComparison = periodComparison(todaySeconds, yesterdaySeconds);
+  const todaySessionCount = sessionList.filter((s) => dayKey(new Date(s.started_at)) === todayKey).length;
+
+  const currentWeekStart = startOfWeek(today);
+  const currentWeekKey = weekKey(today);
+  const previousWeekStart = addDays(currentWeekStart, -7);
+
+  const weekDays = Array.from({ length: 7 }, (_, i) => addDays(currentWeekStart, i));
+  const weekDaySeconds = weekDays.map((d) => totalsByDay.get(dayKey(d)) ?? 0);
+  const weekSeconds = weekDaySeconds.reduce((sum, s) => sum + s, 0);
+  const previousWeekSeconds = Array.from({ length: 7 }, (_, i) => addDays(previousWeekStart, i))
+    .map((d) => totalsByDay.get(dayKey(d)) ?? 0)
+    .reduce((sum, s) => sum + s, 0);
+  const weekComparison = periodComparison(weekSeconds, previousWeekSeconds);
+  const activeDaysThisWeek = weekDaySeconds.filter((s) => s > 0).length;
+  const maxWeekDaySeconds = Math.max(1, ...weekDaySeconds);
+
+  const weekSessions = sessionList.filter((s) => weekKey(new Date(s.started_at)) === currentWeekKey);
+  const topWeekProject = projectTotals(weekSessions, now).filter((p) => p.name !== NO_PROJECT_LABEL)[0] ?? null;
+
+  const todayNote = notes.find((n) => n.scope === "day" && n.date_key === todayKey);
+  const weekNote = notes.find((n) => n.scope === "week" && n.date_key === currentWeekKey);
+
+  return (
+    <div className="grid gap-8 md:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <CalendarDays className="text-muted-foreground size-4" />
+            Today
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div>
+            <p className="text-2xl font-semibold">{formatDuration(todaySeconds)}</p>
+            <ComparisonLine diff={todayComparison.diff} percent={todayComparison.percent} previousLabel="yesterday" />
+          </div>
+          <p className="text-muted-foreground text-sm">
+            {todaySessionCount === 0
+              ? "No sessions yet today."
+              : `${todaySessionCount} session${todaySessionCount === 1 ? "" : "s"} today.`}
+          </p>
+          <NoteEditor
+            scope="day"
+            dateKey={todayKey}
+            note={todayNote}
+            label="today"
+            onSaved={onNoteSaved}
+            onDeleted={() => onNoteDeleted("day", todayKey)}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <CalendarRange className="text-muted-foreground size-4" />
+            This week
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div>
+            <p className="text-muted-foreground text-xs">{formatWeekRangeLabel(currentWeekStart)}</p>
+            <p className="text-2xl font-semibold">{formatDuration(weekSeconds)}</p>
+            <ComparisonLine diff={weekComparison.diff} percent={weekComparison.percent} previousLabel="last week" />
+          </div>
+
+          <p className="text-muted-foreground text-sm">
+            Active {activeDaysThisWeek} day{activeDaysThisWeek === 1 ? "" : "s"} this week
+            {topWeekProject ? ` · mostly ${topWeekProject.name}` : ""}
+          </p>
+
+          <div className="flex h-16 items-end gap-1.5">
+            {weekDays.map((d, i) => {
+              const isToday = dayKey(d) === todayKey;
+              return (
+                <Tooltip key={dayKey(d)}>
+                  <TooltipTrigger
+                    render={
+                      <div className="flex h-full flex-1 flex-col items-center justify-end gap-1">
+                        <div
+                          className={`min-h-[2px] w-full rounded-t-sm ${isToday ? "bg-primary" : "bg-primary/50"}`}
+                          style={{ height: `${(weekDaySeconds[i] / maxWeekDaySeconds) * 100}%` }}
+                        />
+                        <span className="text-muted-foreground text-[10px]">{WEEKDAY_SHORT[i]}</span>
+                      </div>
+                    }
+                  />
+                  <TooltipContent>
+                    {d.toLocaleDateString(undefined, { month: "short", day: "numeric" })}:{" "}
+                    {weekDaySeconds[i] > 0 ? formatDuration(weekDaySeconds[i]) : "no study"}
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </div>
+
+          <NoteEditor
+            scope="week"
+            dateKey={currentWeekKey}
+            note={weekNote}
+            label="this week"
+            onSaved={onNoteSaved}
+            onDeleted={() => onNoteDeleted("week", currentWeekKey)}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -99,6 +99,17 @@ export const sessions = {
     }),
 };
 
+export type Note = { id: number; scope: "day" | "week"; date_key: string; content: string; updated_at: string };
+
+export const notes = {
+  list: () => api<Note[]>("/api/notes"),
+  upsert: (scope: "day" | "week", dateKey: string, content: string) =>
+    api<Note | undefined>(`/api/notes/${scope}/${dateKey}`, {
+      method: "PUT",
+      body: JSON.stringify({ content }),
+    }),
+};
+
 export type Project = { id: number; name: string; icon: string | null };
 
 export const projects = {

--- a/frontend/lib/date.ts
+++ b/frontend/lib/date.ts
@@ -1,0 +1,78 @@
+export function pad(n: number) {
+  return String(n).padStart(2, "0");
+}
+
+export function dayKey(date: Date) {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+export function startOfDay(date: Date) {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function addDays(date: Date, days: number) {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+/** Monday-Sunday week, in the local/user-facing timezone. */
+export function startOfWeek(date: Date) {
+  const d = startOfDay(date);
+  const day = d.getDay(); // 0 = Sunday
+  const diff = day === 0 ? -6 : 1 - day;
+  return addDays(d, diff);
+}
+
+/** Key identifying a week: the date-key of its Monday. */
+export function weekKey(date: Date) {
+  return dayKey(startOfWeek(date));
+}
+
+export function formatDuration(totalSeconds: number) {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  if (hours === 0) return `${minutes}m`;
+  return `${hours}h ${minutes}m`;
+}
+
+export function formatTime(dateStr: string) {
+  return new Date(dateStr).toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+export function formatDayLabel(date: Date, now: Date = new Date()) {
+  const diffDays = Math.round((startOfDay(now).getTime() - startOfDay(date).getTime()) / 86_400_000);
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  return date.toLocaleDateString(undefined, { weekday: "long", month: "short", day: "numeric" });
+}
+
+export function formatWeekRangeLabel(weekStart: Date) {
+  const weekEnd = addDays(weekStart, 6);
+  const sameYear = weekStart.getFullYear() === weekEnd.getFullYear();
+  const startLabel = weekStart.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: sameYear ? undefined : "numeric",
+  });
+  const endLabel = weekEnd.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+  return `${startLabel} – ${endLabel}`;
+}
+
+/**
+ * Duration diff plus a percentage, or null when a percentage wouldn't be meaningful
+ * (previous period had no tracked time but the current one does).
+ */
+export function periodComparison(current: number, previous: number): { diff: number; percent: number | null } {
+  const diff = current - previous;
+  if (previous === 0) {
+    return { diff, percent: current === 0 ? 0 : null };
+  }
+  return { diff, percent: Math.round((diff / previous) * 100) };
+}

--- a/frontend/lib/export.ts
+++ b/frontend/lib/export.ts
@@ -1,0 +1,68 @@
+import { StudySession } from "./api";
+
+const CSV_HEADER = [
+  "Date",
+  "Start Time",
+  "End Time",
+  "Duration (minutes)",
+  "Status",
+  "Project",
+  "Description",
+  "Started At (ISO)",
+  "Ended At (ISO)",
+];
+
+function escapeCsvField(value: string) {
+  if (/[",\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function toCsvRow(fields: (string | number)[]) {
+  return fields.map((field) => escapeCsvField(String(field))).join(",");
+}
+
+/** `now` is used to compute the live duration of any still-running session. */
+export function sessionsToCsv(sessionList: StudySession[], now: number) {
+  const rows = [...sessionList]
+    .sort((a, b) => new Date(a.started_at).getTime() - new Date(b.started_at).getTime())
+    .map((session) => {
+      const start = new Date(session.started_at);
+      const isActive = session.ended_at === null;
+      const end = isActive ? null : new Date(session.ended_at!);
+      const seconds = isActive
+        ? Math.max(0, Math.floor((now - start.getTime()) / 1000))
+        : (session.duration_seconds ?? 0);
+
+      return toCsvRow([
+        start.toLocaleDateString(undefined, { year: "numeric", month: "2-digit", day: "2-digit" }),
+        start.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: false }),
+        end ? end.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: false }) : "",
+        Math.round(seconds / 60),
+        isActive ? "In progress" : "Completed",
+        session.project_name ?? "",
+        session.description ?? "",
+        session.started_at,
+        session.ended_at ?? "",
+      ]);
+    });
+
+  return [toCsvRow(CSV_HEADER), ...rows].join("\n");
+}
+
+export function downloadCsv(filename: string, csv: string) {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export function exportSessions(filename: string, sessionList: StudySession[], now: number) {
+  downloadCsv(filename, sessionsToCsv(sessionList, now));
+}

--- a/frontend/lib/session-stats.ts
+++ b/frontend/lib/session-stats.ts
@@ -1,0 +1,39 @@
+import { StudySession } from "./api";
+import { dayKey } from "./date";
+
+const NO_PROJECT_LABEL = "No project";
+
+/** Live duration for an in-progress session, otherwise its stored duration. */
+export function sessionDurationSeconds(session: StudySession, now: number) {
+  return session.ended_at === null
+    ? Math.max(0, Math.floor((now - new Date(session.started_at).getTime()) / 1000))
+    : (session.duration_seconds ?? 0);
+}
+
+export function dailyTotals(sessionList: StudySession[], now: number) {
+  const totals = new Map<string, number>();
+  for (const session of sessionList) {
+    const key = dayKey(new Date(session.started_at));
+    totals.set(key, (totals.get(key) ?? 0) + sessionDurationSeconds(session, now));
+  }
+  return totals;
+}
+
+export type ProjectTotal = { key: string; name: string; icon: string | null; seconds: number };
+
+export function projectTotals(sessionList: StudySession[], now: number): ProjectTotal[] {
+  const totals = new Map<string, ProjectTotal>();
+  for (const session of sessionList) {
+    const key = session.project_id !== null ? String(session.project_id) : "none";
+    const existing = totals.get(key);
+    totals.set(key, {
+      key,
+      name: session.project_name ?? NO_PROJECT_LABEL,
+      icon: session.project_icon,
+      seconds: (existing?.seconds ?? 0) + sessionDurationSeconds(session, now),
+    });
+  }
+  return Array.from(totals.values()).sort((a, b) => b.seconds - a.seconds);
+}
+
+export { NO_PROJECT_LABEL };


### PR DESCRIPTION
## Summary

Implements four related backlog items together, since they share the same day/week grouping model:

- **#19 — Add notes for days and weeks**: freeform notes attached to a day or a week (new `notes` table + `GET/PUT /api/notes`), editable inline wherever that day/week shows up.
- **#14 — Add an in-app weekly report every Sunday** (scoped to the app's current data model, without the parts that depend on not-yet-built features like nested projects `#15` or the Learning/Producing split `#13`): a "Today" and a "This week" card on the Stats page with total time, comparison to the previous period (duration + %), active-day count, a per-weekday chart, and the top project.
- **#7 — Group history entries by week**: History is now grouped by calendar week (Monday–Sunday, respecting local time) and then by day, newest-first, with a collapsible week header showing the date range and total.
- **#9 — Add history data export options**: CSV export at three scopes — a single day, a single week, or full history — each including raw ISO timestamps so the export can be reconstructed exactly.

## Design notes

- Week boundaries are Monday–Sunday in the browser's local timezone (`lib/date.ts`).
- Comparisons omit a percentage when the previous period had zero tracked time (avoids a meaningless "∞%").
- Day and week notes are shared state: editing "This week"'s note from the report card and from the History week header both hit the same note.
- Export is generated client-side from data already scoped to the signed-in user by the existing `/api/sessions` endpoint — no new data-access surface.
- Kept the existing Add/Edit session dialog behavior unchanged; it now lives in the new `HistorySection` component alongside the grouping.

## Test plan

- [x] Backend and frontend typecheck cleanly (`tsc --noEmit`), lint clean, `next build` succeeds.
- [x] Manually exercised `/api/notes` (create, list, empty-content delete, invalid scope → 400) via curl against a local server.
- [x] Drove the app in headless Chrome: logged in, edited a week note from the report card and confirmed it appears identically in the History week header, collapsed/expanded a week group, and downloaded both an "export all" and a per-week CSV and verified their contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WmxwQzkzLz3KZc5VC8Ud2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds day/week notes, daily/weekly report cards, grouped History, and CSV export to give clearer insights and easier record keeping. Introduces a new `/api/notes` endpoint and shared note editing across views. Addresses #19, #14, #7, and #9.

- **New Features**
  - Notes: freeform notes for a day or week via `notes` table and `/api/notes` (inline edit from Reports and History).
  - Reports: “Today” and “This week” cards with totals, period comparison, active days, weekday chart, and top project.
  - History: grouped by week (Mon–Sun, local time) then day; collapsible week headers with ranges and totals; notes are shared.
  - CSV export: download for a single day, a week, or all history; includes ISO timestamps; generated client-side.
  - Live stats include in-progress session time for accurate totals.

- **Migration**
  - New `notes` table is auto-created on startup; no manual migration needed.
  - New route mounted at `/api/notes`.

<sup>Written for commit 5e98f035b87da1cf38393f28a9834adbc582babe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yesvus/sentinel/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

