### PR TITLE
Add issue templates with P tags and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,0 +1,57 @@
+name: Bug report
+description: Something is not working as documented or expected
+title: "[bug] "
+labels: [bug]
+body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: Apply the matching P0-P3 label on the right sidebar as well.
+      options:
+        - P0-critical (crash, data loss, auth broken)
+        - P1-high (broken workflow, fix soon)
+        - P2-medium (normal, fix when convenient)
+        - P3-low (polish, no urgency)
+      default: 2
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - app (pages, components)
+        - api (route handlers)
+        - db / turso (schema, migrations)
+        - auth (sessions, tokens)
+        - docs
+        - other
+      default: 5
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: One or two sentences.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro
+      description: Exact steps or requests, in order.
+      placeholder: |
+        1. went to ...
+        2. called `PUT /api/v1/...`
+        3. saw ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected
+      description: What should have happened instead.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02-task.yml
+++ b/.github/ISSUE_TEMPLATE/02-task.yml
@@ -1,0 +1,46 @@
+name: Task
+description: Scoped build work, ready to implement
+title: "[task] "
+labels: [task]
+body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: Apply the matching P0-P3 label on the right sidebar as well.
+      options:
+        - P0-critical (do now)
+        - P1-high (land soon)
+        - P2-medium (normal)
+        - P3-low (when convenient)
+      default: 2
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - app (pages, components)
+        - api (route handlers)
+        - db / turso (schema, migrations)
+        - auth (sessions, tokens)
+        - docs
+        - other
+      default: 5
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What ships when this closes.
+    validations:
+      required: true
+  - type: textarea
+    id: plan
+    attributes:
+      label: Plan
+      description: Numbered steps, rough is fine.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/03-idea.yml
+++ b/.github/ISSUE_TEMPLATE/03-idea.yml
@@ -1,0 +1,32 @@
+name: Idea
+description: Feature direction, not yet scoped
+title: "[idea] "
+labels: [enhancement]
+body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: Apply the matching P0-P3 label on the right sidebar as well.
+      options:
+        - P0-critical
+        - P1-high
+        - P2-medium (normal)
+        - P3-low (parked)
+      default: 3
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: The idea in a few sentences.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: Who wants this and what it unlocks.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/04-question.yml
+++ b/.github/ISSUE_TEMPLATE/04-question.yml
@@ -1,0 +1,25 @@
+name: Question
+description: Decision blocking or shaping work
+title: "[question] "
+labels: [question]
+body:
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: Apply the matching P0-P3 label on the right sidebar as well.
+      options:
+        - P0-critical (blocks active work)
+        - P1-high
+        - P2-medium (normal)
+        - P3-low (curiosity)
+      default: 2
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: The decision needed, with options if known.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion
+    url: https://github.com/yesvus/sentinel/discussions
+    about: Not sure it is an issue? Start a discussion instead.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+# Linked issue
+
+Closes #___  <!-- required for bug/task PRs; use `Related to #___` for ideas/questions with no close -->
+
+## What
+
+- ...
+
+## Why
+
+- ...
+
+## How tested
+
+- [ ] `pnpm test` <!-- plus typecheck/lint/build as touched: `pnpm typecheck`, `pnpm lint`, `pnpm build` -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,18 @@ Closes #___  <!-- required for bug/task PRs; use `Related to #___` for ideas/que
 ## How tested
 
 - [ ] `pnpm test` <!-- plus typecheck/lint/build as touched: `pnpm typecheck`, `pnpm lint`, `pnpm build` -->
+
+## Manual test checklist
+
+CI does not run browser/e2e tests. List every route, form, or action this
+PR touches, and check each one off after a **human** verifies it by hand on
+the Vercel Preview deployment for this PR. Agent-authored PRs must not
+self-check these boxes — leave them unchecked for human review.
+
+- [ ]
+
+## Notes
+
+- [ ] DB migration included
+- [ ] Env vars added/changed
+- [ ] Screenshots attached (UI changes)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ PR touches, and check each one off after a **human** verifies it by hand on
 the Vercel Preview deployment for this PR. Agent-authored PRs must not
 self-check these boxes — leave them unchecked for human review.
 
-- [ ]
+- [ ] <route/action to verify>
 
 ## Notes
 


### PR DESCRIPTION
Related to #43.

## What

- ISSUE_TEMPLATE forms (bug/task/idea/question) with required priority field pointing at the P0-P3 sidebar labels
- PR template with issue linkage
- new labels: P0-P3, task

## Why

Backlog (#23-#40) is mostly unlabeled; templates make priority explicit at filing time.

## How tested

- [ ] forms render (check Files changed preview after merge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds issue templates for bug, task, idea, and question with a required priority field referencing P0-P3 labels, plus a PR template requiring a linked issue and a manual preview checklist for human verification.

- Templates require filers to manually apply the matching P0-P3 label; labels are not auto-created.
- Blank issues are disabled and a discussion link is provided for non-issues.
- Agent-authored PRs must leave the manual checklist boxes unchecked for human review.

<sup>Written for commit ac9cb4854e035c01689b21bb60f54380801029b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yesvus/sentinel/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

